### PR TITLE
Add cron watchdog alert script with Telegram notifications

### DIFF
--- a/scripts/cron-watchdog-alert.sh
+++ b/scripts/cron-watchdog-alert.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# cron-watchdog-alert.sh — Runs cron-watchdog and sends Telegram alert on failure
+# Scheduled via LaunchAgent every 4 hours. Zero LLM tokens.
+
+SCRIPTS_DIR="$(dirname "$0")"
+LOG_DIR="$HOME/.openclaw/logs"
+LOG_FILE="$LOG_DIR/cron-watchdog-alert.log"
+mkdir -p "$LOG_DIR"
+
+# Telegram config (kaizen bot)
+BOT_TOKEN=$(python3 -c "
+import json
+with open('$HOME/.openclaw/openclaw.json') as f:
+    cfg = json.load(f)
+print(cfg['channels']['telegram']['accounts']['kaizen']['botToken'])
+" 2>/dev/null)
+CHAT_ID=622376
+
+send_telegram() {
+  local msg="$1"
+  curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+    -d "chat_id=${CHAT_ID}" \
+    -d "text=${msg}" \
+    -d "parse_mode=Markdown" > /dev/null 2>&1
+}
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') Running watchdog..." >> "$LOG_FILE"
+
+RESULT=$(bash "$SCRIPTS_DIR/cron-watchdog.sh" 2>&1)
+EXIT_CODE=$?
+
+if echo "$RESULT" | grep -q "^ALL_OK:"; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') OK" >> "$LOG_FILE"
+else
+  echo "$(date '+%Y-%m-%d %H:%M:%S') PROBLEMS FOUND:" >> "$LOG_FILE"
+  echo "$RESULT" >> "$LOG_FILE"
+  send_telegram "$RESULT"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') Telegram alert sent" >> "$LOG_FILE"
+fi
+
+# Keep log under 1MB
+if [ -f "$LOG_FILE" ] && [ "$(wc -c < "$LOG_FILE")" -gt 1048576 ]; then
+  tail -100 "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/cron-watchdog-alert.sh` — a wrapper around the existing `cron-watchdog.sh` that sends Telegram alerts via the kaizen bot when cron job errors are detected.

## What it does

- Runs `cron-watchdog.sh` (checks for consecutive errors, missed runs, slow jobs)
- If problems found → sends alert to Telegram (chat ID 622376 via kaizen bot)
- If all OK → logs silently
- Auto-rotates log at 1MB

## Scheduling

Installed as macOS LaunchAgent (`com.openclaw.cron-watchdog`) running every 4 hours. Zero LLM token cost.

## Context

Part of a larger cleanup that removed 8 orphan agent health-check crons and fixed the gus (Kaizen) agent's missing file tool access.

---
[Warp conversation](https://app.warp.dev/conversation/1eaeaeca-8743-4dd0-abc9-44bcd9f24e18)

Co-Authored-By: Oz <oz-agent@warp.dev>