### PR TITLE
feat: add llm-wiki skills to agents routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 {{PAID_GROUP_NAME}} → `methodologist` + `copywriter` | Воронки → `creator-marketing`
 PDF → `nano-pdf` | Ресёрч → `deep-research-pro` | Reddit/X → `last30days`
 Бизнес → `business-architect` | Презентации → `presentation` | Астро → `astrologer`
+Вики (ingest) → `llm-wiki-ingest` | Вики (query) → `llm-wiki-query` | Вики (lint) → `llm-wiki-lint`
 
 ---
 

--- a/agents/walter/AGENTS.md
+++ b/agents/walter/AGENTS.md
@@ -33,6 +33,9 @@ Team Lead. Техническое производство: код, скиллы
 | minimax-pdf | Генерация PDF |
 | quality-check | ОТК перед сдачей |
 | skill-and-agent-creator | Создание/улучшение скиллов |
+| llm-wiki-ingest | Загрузка источника в llm-wiki |
+| llm-wiki-query | Поиск и ответы по llm-wiki |
+| llm-wiki-lint | Аудит здоровья llm-wiki |
 
 ---
 


### PR DESCRIPTION
## Summary

Connects the three `llm-wiki` skills to OpenClaw agents in this repo so they can be invoked by name from any working directory.

### Changes

**`AGENTS.md`** — added to skills routing table:
```
Вики (ingest) → llm-wiki-ingest | Вики (query) → llm-wiki-query | Вики (lint) → llm-wiki-lint
```

**`agents/walter/AGENTS.md`** — added to Walter's team skills table:
- `llm-wiki-ingest` — Загрузка источника в llm-wiki
- `llm-wiki-query` — Поиск и ответы по llm-wiki
- `llm-wiki-lint` — Аудит здоровья llm-wiki

### Related

Skills themselves were fixed in [llm-wiki#master](https://github.com/YaroTanko/llm-wiki) (commit 655db16):
- Added `WIKI_ROOT` absolute path config to all 3 `SKILL.md` files
- Added `_meta.json` + `package.json` to match OpenClaw skill format
- Skills synced to `~/.openclaw/skills/`

---
Co-Authored-By: Oz <oz-agent@warp.dev>
Warp conversation: https://app.warp.dev/conversation/e41dcd30-870e-4339-9274-8e47688b2227