### PR TITLE
feat: restart gateway after auto-apply in post-merge hook

### DIFF
--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -15,5 +15,16 @@ else
   echo "⚠️  Auto-apply failed (exit $?). Run manually: bash scripts/apply.sh"
 fi
 
+if command -v openclaw >/dev/null 2>&1; then
+  echo "🔄 Restarting OpenClaw gateway..."
+  if openclaw gateway restart 2>&1; then
+    echo "✅ Gateway restarted."
+  else
+    echo "⚠️  Gateway restart failed. Run manually: openclaw gateway restart"
+  fi
+else
+  echo "⚠️  openclaw not found, skipping gateway restart."
+fi
+
 # Always exit 0 so git operations are never blocked by hook failures.
 exit 0


### PR DESCRIPTION
## Summary
After `git pull` brings new commits, the post-merge hook now automatically:
1. Runs `apply.sh --skip-verify` to sync changes into OpenClaw runtime and workspaces
2. Restarts the OpenClaw gateway so agents pick up the new config

Both steps are fail-safe (hook always exits 0, checks for `openclaw` before restart).

## Changes
- `scripts/hooks/post-merge` — added `openclaw gateway restart` after apply

## Context
- [Conversation](https://app.warp.dev/conversation/5d76f69f-d49c-467f-afb9-94abed5cb446)
- [Plan: Auto-apply after git pull via post-merge hook](https://app.warp.dev/drive/notebook/gZ5b6bNWDXFt0PyrAqQCq9)

Co-Authored-By: Oz <oz-agent@warp.dev>