### PR TITLE
feat: add smoke test and status check to post-merge hook

### DIFF
--- a/scripts/hooks/post-merge
+++ b/scripts/hooks/post-merge
@@ -1,9 +1,12 @@
 #!/bin/bash
-# post-merge hook — auto-apply after git pull
+# post-merge hook — auto-apply, restart, and verify after git pull
 # Installed by: bash scripts/apply.sh --install-hooks
 #
-# This hook runs apply.sh (without verification for speed) every time
-# git pull brings new commits. It never blocks git operations.
+# After git pull brings new commits, this hook:
+#   1. Applies repo changes to OpenClaw runtime and workspaces
+#   2. Restarts the OpenClaw gateway
+#   3. Verifies system status with smoke test
+# It never blocks git operations (always exits 0).
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/../../scripts" && pwd)"
 
@@ -22,8 +25,20 @@ if command -v openclaw >/dev/null 2>&1; then
   else
     echo "⚠️  Gateway restart failed. Run manually: openclaw gateway restart"
   fi
+
+  echo ""
+  echo "🧪 Running smoke test..."
+  if bash "$SCRIPT_DIR/smoke-test.sh"; then
+    echo "✅ Smoke test passed."
+  else
+    echo "⚠️  Smoke test failed. Run manually: bash scripts/smoke-test.sh"
+  fi
+
+  echo ""
+  echo "📊 Checking OpenClaw status..."
+  openclaw status 2>&1 || echo "⚠️  Could not retrieve OpenClaw status."
 else
-  echo "⚠️  openclaw not found, skipping gateway restart."
+  echo "⚠️  openclaw not found, skipping gateway restart and status check."
 fi
 
 # Always exit 0 so git operations are never blocked by hook failures.


### PR DESCRIPTION
## Summary
Extends the post-merge hook to run full verification after `git pull`. The complete pipeline is now:

1. `apply.sh --skip-verify` — sync repo → OpenClaw runtime + workspaces
2. `openclaw gateway restart` — reload agents with new config
3. `smoke-test.sh` — verify installation integrity
4. `openclaw status` — display agent status

All steps are fail-safe (hook always exits 0).

## Changes
- `scripts/hooks/post-merge` — added smoke test and openclaw status steps

## Context
- [Conversation](https://app.warp.dev/conversation/5d76f69f-d49c-467f-afb9-94abed5cb446)
- [Plan](https://app.warp.dev/drive/notebook/gZ5b6bNWDXFt0PyrAqQCq9)

Co-Authored-By: Oz <oz-agent@warp.dev>