### PR TITLE
Fix dependency version and validate local environment startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@marp-team/marp-cli": "^4.0.0",
     "pptxgenjs": "^3.12.0",
-    "mcp-remote": "^1.0.0"
+    "mcp-remote": "^0.1.38"
   },
   "scripts": {
     "apply": "bash scripts/apply.sh",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Updated `mcp-remote` dependency in `package.json` from an unpublished range (`^1.0.0`) to the latest published compatible range (`^0.1.38`) so `npm install` succeeds.
- Installed project dependencies and OpenClaw CLI.
- Ran repository apply + smoke checks and verified OpenClaw gateway startup/health.

## Validation performed
- `npm install`
- `python3 -m pip install --user -r requirements.txt`
- `npm install -g openclaw`
- `bash scripts/smoke-test.sh`
- `bash scripts/apply.sh`
- `bash scripts/start-team.sh` (shows current config-path mismatch warning)
- `openclaw onboard --non-interactive ...`
- `openclaw gateway run` (in tmux session)
- `openclaw health`
- `openclaw status`
- `curl -sf http://127.0.0.1:18789/health`

## Notes
- Gateway is currently running in tmux session `openclaw-gateway-dev`.
- Team bootstrap script currently skips all agents due expected config path mismatch (`~/.openclaw/agents/<character>/openclaw.json` vs runtime internal names). This was observed, not changed in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6ff1e57-f9c4-482b-ad9e-c0707ed14530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6ff1e57-f9c4-482b-ad9e-c0707ed14530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

